### PR TITLE
Changed active policy symbol in api fhir

### DIFF
--- a/api_fhir/apps.py
+++ b/api_fhir/apps.py
@@ -86,7 +86,7 @@ DEFAULT_CFG = {
         "fhir_is_service_ok_code": "is_service_ok",
         "fhir_balance_code": "balance",
         "fhir_balance_default_category": "medical",
-        "fhir_active_policy_status": ("A",)
+        "fhir_active_policy_status": ("A", 2)
     },
     "stu3_fhir_communication_request_config": {
         "fhir_care_rendered_code": "care_rendered",

--- a/api_fhir/configurations/stu3EligibilityConfiguration.py
+++ b/api_fhir/configurations/stu3EligibilityConfiguration.py
@@ -96,4 +96,4 @@ class Stu3EligibilityConfiguration(EligibilityConfiguration):
 
     @classmethod
     def get_fhir_active_policy_status(cls):
-        return cls.get_config().stu3_fhir_eligibility_config.get('fhir_active_policy_status', ('A,'))
+        return cls.get_config().stu3_fhir_eligibility_config.get('fhir_active_policy_status', ('A', 2))


### PR DESCRIPTION
### Summary
Since on of the updates in policy module active policy status is described as integer value of 2, not "A" character, I've included this change in api module