### PR TITLE
Fixed display of urls in api root in django framework

### DIFF
--- a/api_fhir/urls.py
+++ b/api_fhir/urls.py
@@ -3,14 +3,14 @@ from django.urls import include, path
 from rest_framework.routers import DefaultRouter
 
 router = DefaultRouter()
-router.register(r'Patient', views.InsureeViewSet)
+router.register(r'Patient', views.InsureeViewSet, base_name="Patient")
 router.register(r'Location', views.HFViewSet)
-router.register(r'PractitionerRole', views.PractitionerRoleViewSet)
+router.register(r'PractitionerRole', views.PractitionerRoleViewSet, base_name="PractitionerRole")
 router.register(r'Practitioner', views.PractitionerViewSet)
 router.register(r'Claim', views.ClaimViewSet)
-router.register(r'ClaimResponse', views.ClaimResponseViewSet)
+router.register(r'ClaimResponse', views.ClaimResponseViewSet, base_name="ClaimResponse")
 router.register(r'CommunicationRequest', views.CommunicationRequestViewSet)
-router.register(r'EligibilityRequest', views.EligibilityRequestViewSet)
+router.register(r'EligibilityRequest', views.EligibilityRequestViewSet, base_name="EligibilityRequest")
 router.register(r'Coverage', views.CoverageRequestQuerySet)
 
 urlpatterns = [


### PR DESCRIPTION
### SUMMARY
If more than one url ViewSet uses shares same model, api root generated urls are invalid (e.g. Claim and ClaimRepsonse shares same url). Adding base_name removes this issue.