### PR TITLE
Changed base_name to basename in urls

### DIFF
--- a/api_fhir/urls.py
+++ b/api_fhir/urls.py
@@ -3,14 +3,14 @@ from django.urls import include, path
 from rest_framework.routers import DefaultRouter
 
 router = DefaultRouter()
-router.register(r'Patient', views.InsureeViewSet)
+router.register(r'Patient', views.InsureeViewSet, basename="Patient")
 router.register(r'Location', views.HFViewSet)
-router.register(r'PractitionerRole', views.PractitionerRoleViewSet)
+router.register(r'PractitionerRole', views.PractitionerRoleViewSet, basename="PractitionerRole")
 router.register(r'Practitioner', views.PractitionerViewSet)
 router.register(r'Claim', views.ClaimViewSet)
-router.register(r'ClaimResponse', views.ClaimResponseViewSet)
+router.register(r'ClaimResponse', views.ClaimResponseViewSet, basename="ClaimResponse")
 router.register(r'CommunicationRequest', views.CommunicationRequestViewSet)
-router.register(r'EligibilityRequest', views.EligibilityRequestViewSet)
+router.register(r'EligibilityRequest', views.EligibilityRequestViewSet, basename="EligibilityRequest")
 router.register(r'Coverage', views.CoverageRequestQuerySet)
 
 urlpatterns = [


### PR DESCRIPTION
### SUMMARY
The new version of the django rest framework requires the use of "basename" instead of "base_name", therefore the currently used "base_name" must be changed for the new version of drf to be used.